### PR TITLE
Fix handling of commandline flags for update-vm.sh and update VM memory settings

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant::configure("2") do |config|
   config.vm.provider :virtualbox do |vbox, override|
     vbox.customize ["modifyvm", :id,
       "--name", "Java Developer VM",
-      "--memory", 2048,
+      "--memory", 4096,
       "--cpus", 4
     ]
     vbox.gui = true

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -4,16 +4,17 @@ set -e -o pipefail
 CHEFDK_VERSION="1.3.32"
 DOWNLOAD_DIR="/tmp/vagrant-cache/wget"
 REPO_ROOT="/home/vagrant/vm-setup"
+FLAGS=$1
 
 main() {
   setup_chefdk
-  if [[ "$1" == "--verify-only" ]]; then
+  if [[ "$FLAGS" == "--verify-only" ]]; then
     verify_vm
   else
     copy_repo_and_symlink_self
-    [[ "$1" == "--pull" ]] && update_repo
+    [[ "$FLAGS" == "--pull" ]] && update_repo
     update_vm
-    [[ "$1" == "--provision-only" ]] || verify_vm
+    [[ "$FLAGS" == "--provision-only" ]] || verify_vm
   fi
 }
 


### PR DESCRIPTION
This PR:

1. makes the flags being passed to `update-vm.sh` work again
1. gives the VM more memory so Eclipse is actually usable